### PR TITLE
correct parameter order

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -89,9 +89,9 @@ To add a delay to the start of the queue, add the length in seconds to the `mui-
 ```scss
 // 2 second delay before the first shake
 @include mui-series(2s) {
-  .shake  { @include mui-queue(shake(), 2s); }
-  .spin   { @include mui-queue(spin(), 1s, 2s); }
-  .wiggle { @include mui-queue(wiggle()); }
+  .shake  { @include mui-queue(2s, 0s, shake()); }
+  .spin   { @include mui-queue(1s, 2s, spin()); }
+  .wiggle { @include mui-queue(wiggle); }
 }
 ```
 


### PR DESCRIPTION
Also removed the empty `()` from `wiggle`. 
Was getting an error `name: "wiggle-7deg", 40, 50, 60: (transform: rotate(7deg)), 35, 45, 55, 65: (transform: rotate(-7deg)), 0, 30, 70, 100: (transform: rotate(0))) isn't a valid CSS value.`

I know this is just for illustration, but some folks(me) might copy and paste. :hushed: