### PR TITLE
bugfix: wrong keyword

### DIFF
--- a/src/_classes.scss
+++ b/src/_classes.scss
@@ -13,7 +13,7 @@
   .slide-in-left    { @include mui-slide(in,  right); }
   .slide-in-up      { @include mui-slide(in,  bottom); }
   .slide-in-right   { @include mui-slide(in,  left); }
-  .slide-out-down   { @include mui-slide(out, bottom); }
+  .slide-out-down   { @include mui-slide(out, down); }
   .slide-out-right  { @include mui-slide(out, right); }
   .slide-out-up     { @include mui-slide(out, top); }
   .slide-out-left   { @include mui-slide(out, left); }


### PR DESCRIPTION
* This is a bug fix for issue reported in foundation-sites [issue 7086](https://github.com/zurb/foundation-sites/issues/7086)
* Wrong keyword bottom replaced with down