### PR TITLE
Fix description of direction for mui-slide

### DIFF
--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -72,7 +72,7 @@ Creates a sliding transition by translating the element horizontally or vertical
 **Parameters:**
 
 - `state` (Keyword) - State to transition to. (**Default:** in)
-- `direction` (Keyword) - Side of the element to slide from. Can be `top`, `right`, `bottom`, or `left`. (**Default:** left)
+- `direction` (Keyword) - Direction to slide to. Can be `up`, `right`, `down`, or `left`. (**Default:** left)
 - `amount` (Length) - Length of the slide as a percentage value. (**Default:** 100%)
 - `fade` (Boolean) - Set to `true` to fade the element in or out simultaneously. (**Default:** false)
 - `duration` (Duration) - Length (speed) of the transition. (**Default:** null)

--- a/src/transitions/_slide.scss
+++ b/src/transitions/_slide.scss
@@ -1,6 +1,6 @@
 /// Creates a sliding transition by translating the element horizontally or vertically.
 /// @param {Keyword} $state [in] - State to transition to.
-/// @param {Keyword} $direction [left] - Side of the element to slide from. Can be `top`, `right`, `bottom`, or `left`.
+/// @param {Keyword} $direction [left] - Direction to slide to. Can be `up`, `right`, `down`, or `left`.
 /// @param {Length} $amount [100%] - Length of the slide as a percentage value.
 /// @param {Boolean} $fade [false] - Set to `true` to fade the element in or out simultaneously.
 /// @param {Duration} $duration [null] - Length (speed) of the transition.


### PR DESCRIPTION
The description of the direction parameter for mui-slide states that this would be the side to slide from (`top`, `bottom` etc.). Did not work for me though ... after a short tour through the sources it turns out that it is actually the direction to *slide toward*, i.e., it takes the values `up`, `right`, `down` and `left`.