### PR TITLE
Update _zoom.scss

### DIFF
--- a/src/effects/_zoom.scss
+++ b/src/effects/_zoom.scss
@@ -5,8 +5,10 @@
   $from: 0,
   $to: 1
 ) {
+  $fromName: $from * 100;
+  $toName:   $to   * 100;
   $keyframes: (
-    name: 'scale-#{$to}-to-#{$from}',
+    name: 'scale-#{$toName}-to-#{$fromName}',
     0: (transform: scale($from)),
     100: (transform: scale($to)),
   );


### PR DESCRIPTION
Animation has got invalid name and doesn't work.
Issue #96 suggests updating name of animation the same way #61 did it.