### PR TITLE
Resolves `Passing a string to call()` deprecation warning for Sass 4.0

### DIFF
--- a/src/util/_args.scss
+++ b/src/util/_args.scss
@@ -5,7 +5,7 @@
     $arg: nth($args, 1);
 
     @if type-of($arg) == 'string' {
-      @return call($arg);
+      @return call(get-function($arg));
     } @else if type-of($arg) == 'map' {
       @return $arg;
     }

--- a/src/util/_keyframe.scss
+++ b/src/util/_keyframe.scss
@@ -88,7 +88,7 @@ $-mui-custom: 0;
   // Iterate through each map passed in
   @each $map in $maps {
     @if type-of($map) == 'string' {
-      $map: call($map);
+      $map: call(get-function($map));
     }
 
     $map: -mui-keyframe-split($map);


### PR DESCRIPTION
Resolves issue #99 