### PR TITLE
fix: make all keyframe names safe in CSS

### DIFF
--- a/src/effects/_fade.scss
+++ b/src/effects/_fade.scss
@@ -19,11 +19,8 @@
     }
   }
 
-  $fromName: $from * 100;
-  $toName:   $to   * 100;
-
   $keyframes: (
-    name: 'fade-#{$fromName}-to-#{$toName}',
+    name: -mui-string-safe('fade-#{$from}-to-#{$to}'),
     0: (opacity: $from),
     100: (opacity: $to),
   );

--- a/src/effects/_hinge.scss
+++ b/src/effects/_hinge.scss
@@ -56,7 +56,7 @@
   }
 
   $keyframes: (
-    name: 'hinge-#{$state}-#{$from}-#{$axis}-#{$turn-origin}',
+    name: -mui-string-safe('hinge-#{$state}-#{$from}-#{$axis}-#{$turn-origin}'),
     0: (transform: $start, transform-origin: $origin),
     100: (transform: $end),
   );

--- a/src/effects/_shake.scss
+++ b/src/effects/_shake.scss
@@ -6,7 +6,7 @@
   $left: (5, 15, 25, 35, 45, 55, 65, 75, 85, 95);
 
   $keyframes: (
-    name: 'shake-#{($intensity / 1%)}',
+    name: -mui-string-safe('shake-#{$intensity}'),
     $right: (transform: translateX($intensity)),
     $left: (transform: translateX(-$intensity)),
   );

--- a/src/effects/_slide.scss
+++ b/src/effects/_slide.scss
@@ -32,7 +32,7 @@
   }
 
   $keyframes: (
-    name: 'slide-#{$state}-#{$direction}-#{strip-unit($amount)}',
+    name: -mui-string-safe('slide-#{$state}-#{$direction}-#{$amount}'),
     0: (transform: '#{$func}(#{$from})'),
     100: (transform: '#{$func}(#{$to})'),
   );

--- a/src/effects/_spin.scss
+++ b/src/effects/_spin.scss
@@ -19,7 +19,7 @@
   }
 
   $keyframes: (
-    name: 'spin-#{$direction}-#{$amount}',
+    name: -mui-string-safe('spin-#{$direction}-#{$amount}'),
     0: (transform: rotate($start)),
     100: (transform: rotate($end)),
   );

--- a/src/effects/_wiggle.scss
+++ b/src/effects/_wiggle.scss
@@ -3,7 +3,7 @@
 /// @return {Map} A keyframes map that can be used with the `generate-keyframes()` mixin.
 @function wiggle($intensity: 7deg) {
   $keyframes: (
-    name: 'wiggle-#{$intensity}',
+    name: -mui-string-safe('wiggle-#{$intensity}'),
     (40, 50, 60): (transform: rotate($intensity)),
     (35, 45, 55, 65): (transform: rotate(-$intensity)),
     (0, 30, 70, 100): (transform: rotate(0)),

--- a/src/effects/_zoom.scss
+++ b/src/effects/_zoom.scss
@@ -6,7 +6,7 @@
   $to: 1
 ) {
   $keyframes: (
-    name: 'scale-#{$to}-to-#{$from}',
+    name: -mui-string-safe('scale-#{$to}-to-#{$from}'),
     0: (transform: scale($from)),
     100: (transform: scale($to)),
   );

--- a/src/motion-ui.scss
+++ b/src/motion-ui.scss
@@ -11,6 +11,7 @@
 @import 'util/series';
 @import 'util/transition';
 @import 'util/unit';
+@import 'util/string';
 
 @import 'effects/fade';
 @import 'effects/hinge';

--- a/src/util/_string.scss
+++ b/src/util/_string.scss
@@ -1,0 +1,36 @@
+/// Convert any string to a "safe" string that can be used anywhere in CSS (as class or keyframe name for example).
+/// Unsupported characters are replaced by the given `$delimiter` ("-").
+/// Several unsupported characters following each others are replaced by a single delimiter.
+///
+/// @param {*} $str - String to convert. If not a string, it will be converted to with `quote()`.
+/// @param {String} $delimiter ['-'] - Character to use instead of unsupported characters.
+/// @return {String} - Safe string usable everywhere in CSS.
+@function -mui-string-safe(
+  $str,
+  $delimiter: '-'
+) {
+  $str: quote($str);
+  $length: str_length($str);
+  $safe-chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+  $ret: '';
+  $delimited: false;
+
+  @for $i from 1 through $length {
+    $c: str_slice($str, $i, $i);
+
+    @if (str_index($safe-chars, $c) != null) {
+      $ret: '#{$ret}#{$c}';
+      $delimited: false;
+    }
+    @else if (($delimited == false)
+      and (str_length($ret) > 0)
+      and ($i < $length))
+    {
+      $ret: '#{$ret}#{$delimiter}';
+      $delimited: true;
+    }
+  }
+
+  @return $ret;
+}


### PR DESCRIPTION
### Changes:
* add `-mui-string-safe` to make strings safes in CSS
* use `-mui-string-safe`in all effects for keyframe names, instead of case-per-case protections.

Replaces https://github.com/zurb/motion-ui/pull/98
Closes https://github.com/zurb/motion-ui/issues/96