### PR TITLE
feat: change mui-series paused behavior for Safari support #97

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -111,7 +111,7 @@ $('.animation-wrapper').addClass('is-animating');
 
 From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animations working on macOS Safari.
 
-To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
+To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container (or on `<body>` to affect all animations), but animations will not start on macOS Safari.
 
 ## Use with WOW.js
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -109,7 +109,7 @@ $('.animation-wrapper').addClass('is-animating');
 
 ### Paused behavior
 
-From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animation work on macOS Safari.
+From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animations working on macOS Safari.
 
 To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -107,6 +107,12 @@ document.querySelector('.animation-wrapper').classList.add('is-animating');
 $('.animation-wrapper').addClass('is-animating');
 ```
 
+### Paused behavior
+
+From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animation work on macOS Safari.
+
+To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
+
 ## Use with WOW.js
 
 Motion UI can be paired with WOW.js to animate elements in as the page scrolls. [Learn more about WOW.js integration.](wow.md);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'mui-pause',
   activate-queue-class: 'is-animating'
 );
 ```

--- a/docs/src/animations.md
+++ b/docs/src/animations.md
@@ -116,7 +116,7 @@ $('.animation-wrapper').addClass('is-animating');
 
 ### Paused behavior
 
-From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animation work on macOS Safari.
+From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animations working on macOS Safari.
 
 To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
 

--- a/docs/src/animations.md
+++ b/docs/src/animations.md
@@ -118,7 +118,7 @@ $('.animation-wrapper').addClass('is-animating');
 
 From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animations working on macOS Safari.
 
-To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
+To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container (or on `<body>` to affect all animations), but animations will not start on macOS Safari.
 
 ## Use with WOW.js
 

--- a/docs/src/animations.md
+++ b/docs/src/animations.md
@@ -114,6 +114,12 @@ document.querySelector('.animation-wrapper').classList.add('is-animating');
 $('.animation-wrapper').addClass('is-animating');
 ```
 
+### Paused behavior
+
+From Motion UI v1.3.0, the animation is reset when `.is-animating` is removed from an animated or animating element. This is the only way we found to make animation work on macOS Safari.
+
+To rollback to the previous behavior and make the animation pause when `.is-animating` is removed, add `.mui-pause` to the parent container. This can be set on `body` to affect all animations.
+
 ## Use with WOW.js
 
 Motion UI can be paired with WOW.js to animate elements in as the page scrolls. [Learn more about WOW.js integration.](wow.md);

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -58,6 +58,7 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'mui-pause',
   activate-queue-class: 'is-animating'
 );
 ```

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -57,6 +57,6 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
-  pause-queue-class: 'pause',
+  pause-queue-class: 'mui-pause',
   activate-queue-class: 'is-animating',
 ) !default;

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -57,5 +57,6 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'pause',
   activate-queue-class: 'is-animating',
 ) !default;

--- a/src/util/_series.scss
+++ b/src/util/_series.scss
@@ -1,10 +1,12 @@
 $-mui-queue: ();
 
-/// Pauses the animation on an element by default, and then plays it when an active class is added to a parent. Also sets the fill mode of the animation to `both`. This pauses the element at the first frame of the animation, and holds it in place at the end.
+/// Pauses the animation on an element by default, and then plays it when an active class is added to a parent.
+/// This is not supported by Safari. See https://git.io/motion-ui-97
+///
+/// @since v1.3.0
 /// @access private
-%animated-element {
+%paused-element {
   animation-play-state: paused;
-  animation-fill-mode: both;
 
   .#{map-get($motion-ui-settings, activate-queue-class)} & {
     animation-play-state: running;
@@ -56,7 +58,15 @@ $-mui-queue: ();
   animation-fill-mode: both;
 
   // By default, animation name is set to start the animation
-  .#{map-get($motion-ui-settings, activate-queue-class)} & {
+  .#{map-get($motion-ui-settings, activate-queue-class)} &,
+  // For pausable animation, animation name must be initialy set
+  .#{map-get($motion-ui-settings, pause-queue-class)} & {
     @include mui-animation($kf);
+  }
+
+  // Pausable animation.
+  // This was the behavior before v1.3.0. See https://git.io/motion-ui-97
+  .#{map-get($motion-ui-settings, pause-queue-class)} & {
+    @extend %paused-element;
   }
 }

--- a/src/util/_series.scss
+++ b/src/util/_series.scss
@@ -46,9 +46,17 @@ $-mui-queue: ();
   $item: ($duration, $gap);
   $-mui-queue: append($-mui-queue, $item) !global;
 
-  // CSS output
-  @extend %animated-element;
-  @include mui-animation($kf);
-  animation-duration: $duration;
+  // --- CSS output ---
+  // Initial properties
+  @include -mui-keyframe-get($kf, 0);
+
+  // Animation properties (except name)
   animation-delay: $actual-delay;
+  animation-duration: $duration;
+  animation-fill-mode: both;
+
+  // By default, animation name is set to start the animation
+  .#{map-get($motion-ui-settings, activate-queue-class)} & {
+    @include mui-animation($kf);
+  }
 }


### PR DESCRIPTION
The previous and latest versions of macOS Safari do not handle correctly `animation-play-state` with `animation-fill-mode` and the animation never start. See #97 for more informations.

This PR allow the animation to run but also introduce breaking changes.

### Changes

* 11dde5e **Change mui-series behavior for better Safari support**
  Do not set the animation name until it need to be played. This is the only way to control the animation start on all browsers (including latest Safari versions). See issue for more informations.

* efd6e38 **Add "pause" mui-series modifier to rollback to pause behavior**
  Old behavior can be recoverd with the `.mui-pause` modifier

* 290855e Update documentation about mui-series paused behavior and rollback 

### ⚠️ BREAKING CHANGE
When `.is-animating` is removed from `.mui-series`, the animation is now reset instead of paused. Setting `.is-animating` back will start the animation from its begining.

Closes #97