### PR TITLE
feat: change mui-series pause behavior & add `.is-paused` for Safari support #97

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -97,7 +97,7 @@ To add a delay to the start of the queue, add the length in seconds to the `mui-
 }
 ```
 
-To trigger the queue, add the class `.is-animating` to the parent container. This can be done easily in JavaScript:
+**To play the queue**, add the class `.is-animating` to the parent container. This can be done easily in JavaScript:
 
 ```js
 // Plain JavaScript (IE10+)
@@ -106,6 +106,10 @@ document.querySelector('.animation-wrapper').classList.add('is-animating');
 // jQuery
 $('.animation-wrapper').addClass('is-animating');
 ```
+
+**To pause the queue**, add `.is-paused` to the parent container (without removing `.is-animating`). For macOS Safari to correctly play pause the animation, `.is-paused` must not be set by default but only after `.is-animating`. See https://git.io/motion-ui-97.
+
+**To reset the queue** to its initial state, remove `.is-animating` and `.is-paused` from the parent container. The queue can then be started again.
 
 ## Use with WOW.js
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'is-paused',
   activate-queue-class: 'is-animating'
 );
 ```

--- a/docs/src/animations.md
+++ b/docs/src/animations.md
@@ -104,7 +104,7 @@ To add a delay to the start of the queue, add the length in seconds to the `mui-
 }
 ```
 
-To trigger the queue, add the class `.is-animating` to the parent container. This can be done easily in JavaScript:
+**To play the queue**, add the class `.is-animating` to the parent container. This can be done easily in JavaScript:
 
 ```js
 // Plain JavaScript (IE10+)
@@ -113,6 +113,10 @@ document.querySelector('.animation-wrapper').classList.add('is-animating');
 // jQuery
 $('.animation-wrapper').addClass('is-animating');
 ```
+
+**To pause the queue**, add `.is-paused` to the parent container (without removing `.is-animating`). For macOS Safari to correctly play pause the animation, `.is-paused` must not be set by default but only after `.is-animating`. See https://git.io/motion-ui-97.
+
+**To reset the queue** to its initial state, remove `.is-animating` and `.is-paused` from the parent container. The queue can then be started again.
 
 ## Use with WOW.js
 

--- a/docs/src/animations.md
+++ b/docs/src/animations.md
@@ -85,11 +85,11 @@ Begin your series with the `mui-series()` mixin. Inside this mixin, attach anima
 ```scss
 @include mui-series {
   // 2 second shake
-  .shake    { @include mui-queue(2s, 0s, shake); }
+  .my-queue-shake     { @include mui-queue(2s, 0s, shake); }
   // 1 second spin with a 2 second pause
-  .spin     { @include mui-queue(1s, 2s, spin); }
+  .my-queue-spin      { @include mui-queue(1s, 2s, spin); }
   // 1 second zoom and fade
-  .fade-zoom { @include mui-queue(1s, 0s, fade, zoom); }
+  .my-queue-fade-zoom { @include mui-queue(1s, 0s, fade, zoom); }
 }
 ```
 
@@ -98,9 +98,9 @@ To add a delay to the start of the queue, add the length in seconds to the `mui-
 ```scss
 // 2 second delay before the first shake
 @include mui-series(2s) {
-  .shake  { @include mui-queue(2s, 0s, shake()); }
-  .spin   { @include mui-queue(1s, 2s, spin()); }
-  .wiggle { @include mui-queue(wiggle); }
+  .my-queue-shake     { @include mui-queue(2s, 0s, shake()); }
+  .my-queue-spin      { @include mui-queue(1s, 2s, spin()); }
+  .my-queue-wiggle    { @include mui-queue(wiggle); }
 }
 ```
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -58,6 +58,7 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'is-paused',
   activate-queue-class: 'is-animating'
 );
 ```

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -57,5 +57,6 @@ $motion-ui-settings: (
   hinge-and-fade: true,
   scale-and-fade: true,
   spin-and-fade: true,
+  pause-queue-class: 'is-paused',
   activate-queue-class: 'is-animating',
 ) !default;

--- a/src/util/_series.scss
+++ b/src/util/_series.scss
@@ -46,4 +46,10 @@ $-mui-queue: ();
     animation-delay: $actual-delay;
     animation-duration: $duration;
   }
+
+  // Pause the animation
+  // This was the behavior before v1.3.0. See https://git.io/motion-ui-97
+  .#{map-get($motion-ui-settings, pause-queue-class)} & {
+    animation-play-state: paused;
+  }
 }

--- a/src/util/_series.scss
+++ b/src/util/_series.scss
@@ -1,16 +1,5 @@
 $-mui-queue: ();
 
-/// Pauses the animation on an element by default, and then plays it when an active class is added to a parent. Also sets the fill mode of the animation to `both`. This pauses the element at the first frame of the animation, and holds it in place at the end.
-/// @access private
-%animated-element {
-  animation-play-state: paused;
-  animation-fill-mode: both;
-
-  .#{map-get($motion-ui-settings, activate-queue-class)} & {
-    animation-play-state: running;
-  }
-}
-
 /// Creates a new animation queue.
 /// @param {Duration} $delay [0s] - Delay in seconds or milliseconds to place at the front of the animation queue.
 @mixin mui-series($delay: 0s) {
@@ -46,9 +35,15 @@ $-mui-queue: ();
   $item: ($duration, $gap);
   $-mui-queue: append($-mui-queue, $item) !global;
 
-  // CSS output
-  @extend %animated-element;
-  @include mui-animation($kf);
-  animation-duration: $duration;
-  animation-delay: $actual-delay;
+  // --- CSS output ---
+  // Initial properties
+  @include -mui-keyframe-get($kf, 0);
+  animation-fill-mode: both;
+
+  // Start the animation
+  .#{map-get($motion-ui-settings, activate-queue-class)} & {
+    @include mui-animation($kf);
+    animation-delay: $actual-delay;
+    animation-duration: $duration;
+  }
 }

--- a/src/util/_series.scss
+++ b/src/util/_series.scss
@@ -47,8 +47,10 @@ $-mui-queue: ();
     animation-duration: $duration;
   }
 
-  // Pause the animation
-  // This was the behavior before v1.3.0. See https://git.io/motion-ui-97
+  // Pause the animation.
+  // For macOS Safari to play it correctly, `animation-play-state`
+  // must not be `paused` before the animation start.
+  // See https://git.io/motion-ui-97
   .#{map-get($motion-ui-settings, pause-queue-class)} & {
     animation-play-state: paused;
   }


### PR DESCRIPTION
### Bug:

When `animation-play-state: paused` is set before the animation start, macOS Safari does not start the animation, even after `animation-play-state: running` is set. If `animation-play-state: paused` is set later, macOS Safari correctly play and pause the animation.

See https://github.com/zurb/motion-ui/issues/97#issuecomment-386896941 for more informations.

### Fix:

The new queue behavior is the following:
* At first no `animation-name` is set and the first frame properties are applied. So it looks like the animation is paused at the first frame.
* Start the animation with `.is-animating` (set `animation-name`)
* Pause the animation with `.is-paused` (`animation-play-state: paused`)
* Restart the animation by removing `.is-paused`
* Reset the animation by removing `.is-animating`

### Changes:

* 13bb2de **Change mui-series behavior for better Safari support**
  Do not set the animation name until it need to be played. This is the only way to control the animation start on all browsers (including latest Safari versions). See issue for more informations.

* efd6e38 **Add `.is-paused` mui-series modifier to pause the queue**
  As `.is-paused` is not set when the animation start, macOS Safari handle it correctly and can play and pause the animation.

* 290855e Add documentation to play, pause and reset mui-series

### ⚠️ BREAKING CHANGE
* When `.is-animating` is removed from `.mui-series`, the queue is now reset instead of paused. Setting `.is-animating` back will start the queue from its begining.
  
  From now: set `.is-paused` (without removing `.is-animating`) to pause the queue. Remove both `.is-animating` and `.is-paused` to reset the queue.
* Standard animations names are not supported anymore as `mui-series` queues names. Make sure you use unique names for your `mui-series` queues.
  
  ~~**Before**~~
  ```scss
  @include mui-series {
    .shake         { @include mui-queue(3s, 0s, shake); }
    .spin          { @include mui-queue(3s, 0s, spin); }
  }
  ```

  **After**
  ```scss
  @include mui-series {
    .my-serie-shake { @include mui-queue(3s, 0s, shake); }
    .my-serie-spin  { @include mui-queue(3s, 0s, spin); }
  }
  ```

---

- Replaces https://github.com/zurb/motion-ui/pull/107
- Closes #97