### PR TITLE
fix: ensure `-mui-keyframe-pct` returns a strintg instead of a list

### DIFF
--- a/src/util/_keyframe.scss
+++ b/src/util/_keyframe.scss
@@ -36,7 +36,7 @@ $-mui-custom: 0;
     }
   }
 
-  @return $output;
+  @return "#{$output}";
 }
 
 /// Prints the CSS properties from a specific key in a keyframes map. Used to borrow CSS from keyframe functions for use in transitions.


### PR DESCRIPTION
`-mui-keyframe-pct` should return a String. The current implementation may return a list in some Sass versions.

See tests:
> 1) Keyframe
>      Keyframe Percent [function]:
>
>     AssertionError [ERR_ASSERTION]: Converts a single number into a string with a percentage ("[number] 0%" assert-equal "[string] 0%" -- variable types do not match (set `$inspect: true` to compare output values))
>     + expected - actual
>
>     -[number] 0%
>     +[string] 0%

### Changes:
* Ensure that `@function -mui-keyframe-pct` returns a String.