### PR TITLE
chore: add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js: "stable"
+
+matrix:
+  include:
+  - env: MUI_SASS_VERSIONS=3
+  - env: MUI_SASS_VERSIONS=4.8
+  - env: MUI_SASS_VERSIONS=latest
+
+install:
+  - npm i
+  - npm install -g node-sass@$MUI_SASS_VERSIONS
+script:
+  - npm run test
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Motion UI
 
+[![Build Status](https://travis-ci.org/zurb/motion-ui.svg?branch=develop)](https://travis-ci.org/zurb/motion-ui)
 [![CDNJS](https://img.shields.io/cdnjs/v/motion-ui.svg)](https://cdnjs.com/libraries/motion-ui/)
 [![dependencies Status](https://david-dm.org/zurb/motion-ui/status.svg)](https://david-dm.org/zurb/motion-ui)
 [![devDependencies Status](https://david-dm.org/zurb/motion-ui/dev-status.svg)](https://david-dm.org/zurb/motion-ui?type=dev)


### PR DESCRIPTION
From `sass-true@4`, True uses the peer `node-sass` version to run tests, so we can customize the used node-sass version by installing it in global.

Run tests across multiple node-sass versions on travis-ci: `v3` (`v3.13.1`), `v4.8` (`v4.8.3`) and `latest` (`v4.9.0`).

#### Changes
* Add `travis-ci.yml` config file
* Add TravisCI build tag in `README.md`