### PR TITLE
chore: move jQuery to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3832,11 +3832,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-    },
     "js-base64": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sass-true": "^4.0.0",
     "supercollider": "^1.0.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=2.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,10 +2099,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jquery@>=2.2.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-
 js-base64@^2.1.8:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"


### PR DESCRIPTION
## Description

Move `jquery` from `dependencies` to `peerDependencies`.

## Motivation and Context

peerDependencies is for dependencies that are exposed to (and expected to be used by) the consuming code, as opposed to "private" dependencies that are not exposed, and are only an implementation detail.

We still need `jQuery` in peerDependencies instead of dependencies because we actually expect the user to install it. We cannot simply remove it because we still need the package managers to check for versions compatibilities and warn the user if it is missing.

Related to https://github.com/zurb/foundation-sites/pull/11294
See https://github.com/zurb/foundation-sites/issues/11290