### PR TITLE
fix: revert "6059743 unpin Meteor fourseven for better compatibility"

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,8 +8,8 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
-  api.imply('fourseven:scss');
-  api.use(['ecmascript', 'jquery', 'fourseven:scss'], 'client');
+  api.imply('fourseven:scss@3.4.1');
+  api.use(['ecmascript', 'jquery', 'fourseven:scss@3.4.1'], 'client');
   api.addFiles('dist/motion-ui.js', 'client');
   api.addFiles([
     'src/_settings.scss',


### PR DESCRIPTION
It's a mistake of my own, I did not understood that Meteor will use versions to get "at least" the given version on installation. Removing it make Meteor searching for `fourseven:scss@0.9.6` and break Sass compilation.

### Changes:
* Revert 6059743 "Unpin Meteor fourseven for better compatibility"

**Note**: The proper solution could be to update to Meteor v1.7.0.