### PR TITLE
fix: revise Meteor "fourseven:scss" compatibility for Meteor<1.4.1 support

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,8 +8,8 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
-  api.imply('fourseven:scss@3.4.1');
-  api.use(['ecmascript', 'jquery', 'fourseven:scss@3.4.1'], 'client');
+  api.imply('fourseven:scss@3.4.1 || 4.0.0');
+  api.use(['ecmascript', 'jquery', 'fourseven:scss@3.4.1 || 4.0.0'], 'client');
   api.addFiles('dist/motion-ui.js', 'client');
   api.addFiles([
     'src/_settings.scss',


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

Revise `fourseven:scss` compatibility to `3.4.1 || 4.0.0` to support older and newer Meteor versions.

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

Foundation supports a large range of versions for `fourseven:scss` (from `v3.4`) and Meteor (from `v1.2.1`). Meteor packages version resolution will use all newer minor and patch versions but not major versions.

As `fourseven:scss` versions require a particular Meteor versions, the latest releases are considered as incompatible with Motion UI. This pull request ensures that the Motion UI actual compatibility with Meteor and its packages matches the compatibility allowed by Meteor package management.

Related to https://github.com/zurb/foundation-sites/pull/11349

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
