### PR TITLE
🚀 Release v2.0.3

### DIFF
--- a/.versions
+++ b/.versions
@@ -1,0 +1,15 @@
+babel-compiler@5.8.24_1
+babel-runtime@0.1.4
+base64@1.0.4
+caching-compiler@1.0.0
+check@1.1.0
+ecmascript@0.1.6
+ecmascript-runtime@0.2.6
+ejson@1.0.7
+fourseven:scss@3.4.3
+jquery@1.11.4
+meteor@1.1.10
+promise@0.5.1
+random@1.0.5
+underscore@1.0.4
+zurb:motion-ui@2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 2.0.3 (23 June 2018)
+
+This version makes Motion UI compatible with Meteor > 1.4.1 by allowing Meteor to use newer versions of the `fourseven:scss` dependency. Motion UI stays compatible with Meteor v1.2.1 and above.
+
+## 📄  Changes
+* 🐛  #125 - Revise Meteor `fourseven:scss` compatibility to support Meteor>1.4.1 support (@ncoden)
+
 # 2.0.2 (13 June 2018)
 
 This version fixes an issue introduced in `v2.0.1` preventing Meteor build and update Meteor installation documentation. It is fully compatible with `v2.0.1` and do not introduce any API change.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "motion-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "authors": [
     "ZURB <foundation@zurb.com>"
   ],

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "zurb/motion-ui",
   "description": "Sass library for creating transitions and animations.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "css",
     "sass",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "motion-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,6 +30,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -41,6 +42,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4514,7 +4516,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'zurb:motion-ui',
-  version: '2.0.2',
+  version: '2.0.3',
   summary: 'Sass library for creating transitions and animations',
   git: 'https://github.com/zurb/motion-ui.git',
   documentation: 'meteor-README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "motion-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Sass library for creating transitions and animations.",
   "main": "dist/motion-ui.js",
   "scripts": {


### PR DESCRIPTION
# Motion UI v2.0.3

This version makes Motion UI compatible with Meteor > 1.4.1 by allowing Meteor to use newer versions of the `fourseven:scss` dependency. Motion UI stays compatible with Meteor v1.2.1 and above.

## 📄  Changes
* 🐛  #125 - Revise Meteor `fourseven:scss` compatibility to support Meteor>1.4.1 support (@ncoden)

# Release Checklist
* [x] Bump versions
* [x] ~~Update documentation~~ (no changes)
* [x] ~~Update dist files~~ (no changes)
* [x] Update `CHANGELOG.md`
